### PR TITLE
depend on openjdk for catalina macos onwards

### DIFF
--- a/coursier.rb
+++ b/coursier.rb
@@ -15,8 +15,8 @@ class Coursier < Formula
     sha256 "d3ba37e53d9cfa778af481c7099cd1dc485242283e9d2c5c2753f3859908cbd4"
   end
 
-  depends_on java: "1.8+" if MacOS.version < :big_sur
-  depends_on "openjdk" if MacOS.version >= :big_sur
+  depends_on java: "1.8+" if MacOS.version < :catalina
+  depends_on "openjdk" if MacOS.version >= :catalina
 
   def install
     bin.install "cs-x86_64-apple-darwin" => "cs"


### PR DESCRIPTION
This is to resolve following warning I got when updating coursier via homebrew on macos catalina today: 

```
Warning: Calling depends_on :java is deprecated! Use "depends_on "openjdk@11", "depends_on "openjdk@8" or "depends_on "openjdk" instead.
Please report this issue to the coursier/formulas tap (not Homebrew/brew or Homebrew/core), or even better, submit a PR to fix it:
  /usr/local/Homebrew/Library/Taps/coursier/homebrew-formulas/coursier.rb:18

Warning: Calling depends_on :java is deprecated! Use "depends_on "openjdk@11", "depends_on "openjdk@8" or "depends_on "openjdk" instead.
Please report this issue to the coursier/formulas tap (not Homebrew/brew or Homebrew/core), or even better, submit a PR to fix it:
  /usr/local/Homebrew/Library/Taps/coursier/homebrew-formulas/coursier.rb:18
```
