### PR TITLE
Add passthrough for mirrors file environment variable.

### DIFF
--- a/coursier.rb
+++ b/coursier.rb
@@ -21,9 +21,11 @@ class Coursier < Formula
     resource("jar-launcher").stage { bin.install "coursier" }
 
     unless build.without? "zsh-completions"
-      chmod 0555, bin/"coursier"
-      output = Utils.safe_popen_read("#{bin}/coursier", "--completions", "zsh")
-      (zsh_completion/"_coursier").write output
+      with_env("COURSIER_MIRRORS": ENV["HOMEBREW_COURSIER_MIRRORS"]) do
+        chmod 0555, bin/"coursier"
+        output = Utils.safe_popen_read("#{bin}/coursier", "--completions", "zsh")
+        (zsh_completion/"_coursier").write output
+      end
     end
   end
 


### PR DESCRIPTION
Brew sandboxes installation in such a way that the mirrors.properties file referenced in the docs isnt' easily available. Brew overrides `$HOME` and filters out almost all environment variables that don't start with "HOMEBREW_", so the application config file location is a temporary directory and you can't directly pass `COURSIER_MIRRORS` or  to the installer.

This was the most minimally intrusive change I could find to fix the issue, it allows the user to set `HOMEBREW_COURSIER_MIRRORS` as an environment variable and the install section of the formula temporarily forwards that value to coursier as `COURSIER_MIRRORS` .

This should resolve coursier/coursier#1953