### PR TITLE
Support for Apple Silicon

### DIFF
--- a/coursier.rb
+++ b/coursier.rb
@@ -8,7 +8,7 @@ class Coursier < Formula
     sha256 "db49faf31b5ef824394530c4ba6b1d584604e98a546502b15b8a6f0488e78d26"
   end
   on_arm do
-    url "https://github.com/VirtusLab/coursier-m1/releases/download/v2.1.7/cs-aarch64-apple-darwin.gz"
+    url "https://github.com/coursier/coursier/releases/download/v2.1.7/cs-aarch64-apple-darwin.gz"
     sha256 "4da2fa206735017b31ff143e7ad1d23f695a8dc41361e9dd42f4a69136197742"
   end
 

--- a/coursier.rb
+++ b/coursier.rb
@@ -4,7 +4,7 @@ class Coursier < Formula
   homepage "https://get-coursier.io"
   version "2.1.7"
   on_intel do
-    url "https:a//github.com/coursier/coursier/releases/download/v2.1.7/cs-x86_64-apple-darwin.gz"
+    url "https://github.com/coursier/coursier/releases/download/v2.1.7/cs-x86_64-apple-darwin.gz"
     sha256 "db49faf31b5ef824394530c4ba6b1d584604e98a546502b15b8a6f0488e78d26"
   end
   on_arm do

--- a/coursier.rb
+++ b/coursier.rb
@@ -2,9 +2,15 @@
 class Coursier < Formula
   desc "Launcher for Coursier"
   homepage "https://get-coursier.io"
-  url "https://github.com/coursier/coursier/releases/download/v2.1.7/cs-x86_64-apple-darwin.gz"
   version "2.1.7"
-  sha256 "db49faf31b5ef824394530c4ba6b1d584604e98a546502b15b8a6f0488e78d26"
+  on_intel do
+    url "https:a//github.com/coursier/coursier/releases/download/v2.1.7/cs-x86_64-apple-darwin.gz"
+    sha256 "db49faf31b5ef824394530c4ba6b1d584604e98a546502b15b8a6f0488e78d26"
+  end
+  on_arm do
+    url "https://github.com/VirtusLab/coursier-m1/releases/download/v2.1.7/cs-aarch64-apple-darwin.gz"
+    sha256 "4da2fa206735017b31ff143e7ad1d23f695a8dc41361e9dd42f4a69136197742"
+  end
 
   option "without-shell-completions", "Disable shell completion installation"
 
@@ -17,7 +23,12 @@ class Coursier < Formula
   depends_on "openjdk"
 
   def install
-    bin.install "cs-x86_64-apple-darwin" => "cs"
+    on_intel do
+      bin.install "cs-x86_64-apple-darwin" => "cs"
+    end
+    on_arm do
+      bin.install "cs-aarch64-apple-darwin" => "cs"
+    end
     resource("jar-launcher").stage { bin.install "coursier" }
 
     unless build.without? "shell-completions"


### PR DESCRIPTION
I'm using Apple Silicon Mac, found this formula supports Intel Mac only.
So I fix this formula using https://github.com/VirtusLab/coursier-m1
NOTE: I found above repo in https://www.scala-lang.org/download/ .

```console
❯ brew install mtgto/formulas/coursier
==> Tapping mtgto/formulas
Cloning into '/opt/homebrew/Library/Taps/mtgto/homebrew-formulas'...
remote: Enumerating objects: 374, done.
remote: Counting objects: 100% (124/124), done.
remote: Compressing objects: 100% (84/84), done.
remote: Total 374 (delta 40), reused 122 (delta 40), pack-reused 250
Receiving objects: 100% (374/374), 52.04 KiB | 17.34 MiB/s, done.
Resolving deltas: 100% (120/120), done.
Tapped 1 formula (14 files, 69.7KB).
==> Downloading https://formulae.brew.sh/api/formula.jws.json
######################################################################################################################################################### 100.0%
==> Fetching mtgto/formulas/coursier
==> Downloading https://github.com/coursier/coursier/releases/download/v2.1.7/coursier
Already downloaded: /Users/user/Library/Caches/Homebrew/downloads/a16bf6eedb77e3dabe42f4a4d0c02eed207523dafec69873ebf3d8fdb2491001--coursier
==> Downloading https://github.com/VirtusLab/coursier-m1/releases/download/v2.1.7/cs-aarch64-apple-darwin.gz
==> Downloading from https://objects.githubusercontent.com/github-production-release-asset-2e65be/518849181/ae23a78e-c6a7-4881-a461-5e423a0fdbf6?X-Amz-Algorithm
######################################################################################################################################################### 100.0%
==> Installing coursier from mtgto/formulas
Picked up _JAVA_OPTIONS: -Duser.home=/Users/user/Library/Caches/Homebrew/java_cache
Picked up _JAVA_OPTIONS: -Duser.home=/Users/user/Library/Caches/Homebrew/java_cache
==> Downloading https://formulae.brew.sh/api/cask.jws.json
######################################################################################################################################################### 100.0%
==> Caveats
zsh completions have been installed to:
  /opt/homebrew/share/zsh/site-functions
==> Summary
🍺  /opt/homebrew/Cellar/coursier/2.1.7: 6 files, 59.8MB, built in 3 seconds
==> Running `brew cleanup coursier`...
Disable this behaviour by setting HOMEBREW_NO_INSTALL_CLEANUP.
Hide these hints with HOMEBREW_NO_ENV_HINTS (see `man brew`).
```

```console
❯ cs setup
Checking if a JVM is installed
Found a JVM installed under /Users/user/.sdkman/candidates/java/current.

Checking if ~/Library/Application Support/Coursier/bin is in PATH

Checking if the standard Scala applications are installed
  Installed ammonite
  Installed cs
  Installed coursier
  Installed scala
  Installed scalac
  Installed scala-cli
  Installed sbt
  Installed sbtn
  Installed scalafmt
```