### PR TITLE
added mac arm branch

### DIFF
--- a/coursier.rb
+++ b/coursier.rb
@@ -2,9 +2,16 @@
 class Coursier < Formula
   desc "Launcher for Coursier"
   homepage "https://get-coursier.io"
-  url "https://github.com/coursier/coursier/releases/download/v2.1.25-M2/cs-x86_64-apple-darwin.gz"
   version "2.1.25-M2"
-  sha256 "0b51059d28338351e87374f34349d43a00dd445428ad09f0c5db1d8bc7c99997"
+ 
+  on_intel do
+    url "https://github.com/coursier/coursier/releases/download/v2.1.25-M2/cs-x86_64-apple-darwin.gz"
+    sha256 "0b51059d28338351e87374f34349d43a00dd445428ad09f0c5db1d8bc7c99997"
+  end
+  on_arm do 
+    url "https://github.com/coursier/coursier/releases/download/v2.1.25-M2/cs-aarch64-apple-darwin.gz"
+    sha256 "008e10f23ecf59e7a7ee51eeff6be5c971199a95ccc35a8099a451009f6adf0b"
+  end
 
   option "without-shell-completions", "Disable shell completion installation"
 
@@ -17,7 +24,12 @@ class Coursier < Formula
   depends_on "openjdk"
 
   def install
-    bin.install "cs-x86_64-apple-darwin" => "cs"
+    on_intel do
+      bin.install "cs-x86_64-apple-darwin" => "cs"
+    end
+    on_arm do
+      bin.install "cs-aarch64-apple-darwin" => "cs"
+    end
     resource("jar-launcher").stage { bin.install "coursier" }
 
     unless build.without? "shell-completions"


### PR DESCRIPTION
On a mac M1, `brew install coursier/formulas/coursier` works installation-wise, while `cs setup` returns:
```
 ~ cs setup
The current machine does not support all of the following CPU features that are required by the image: [CX8, CMOV, FXSR, MMX, SSE, SSE2, SSE3, SSSE3, SSE4_1, SSE4_2, POPCNT, LZCNT, AVX, AVX2, BMI1, BMI2, FMA].
Please rebuild the executable with an appropriate setting of the -march option.
```

it seems the arm branch in the formula has been removed. Adding the branch and the url make it work.